### PR TITLE
fix: corregida desalineación en animación hover del botón de estrella de GitHub

### DIFF
--- a/src/components/GitHubStar.astro
+++ b/src/components/GitHubStar.astro
@@ -44,7 +44,7 @@ function formatToK(num: number) {
           >{`${formatToK(starCounter)} estrellas en GitHub`}</span
         >
         <span
-          class="absolute opacity-0 -translate-y-5 group-hover:animate-fade-in-up"
+          class="absolute opacity-0 group-hover:animate-fade-in-up"
           >¡Dale una estrella!</span
         >
       </div>


### PR DESCRIPTION
Se corrigió un pequeño bug visual en la animación del botón que muestra las estrellas de GitHub.  

El texto “¡Dale una estrella!” se desplazaba hacia arriba de forma incorrecta al hacer hover.  
Esto se solucionó removiendo la clase `-translate-y-5` en el segundo `<span>` del componente.

Mejora la presentación visual del sitio sin afectar la funcionalidad existente.
